### PR TITLE
Update to OpenSSH 8.4p1

### DIFF
--- a/Formula/openssh-patched.rb
+++ b/Formula/openssh-patched.rb
@@ -1,9 +1,9 @@
 class OpensshPatched < Formula
   desc "OpenBSD freely-licensed SSH connectivity tools with some patches"
   homepage "https://www.openssh.com/"
-  url "https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-8.1p1.tar.gz"
-  version "8.1p1"
-  sha256 "02f5dbef3835d0753556f973cd57b4c19b6b1f6cd24c03445e23ac77ca1b93ff"
+  url "https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-8.4p1.tar.gz"
+  version "8.4p1"
+  sha256 "5a01d22e407eb1c05ba8a8f7c654d388a13e9f226e4ed33bd38748dafa1d2b24"
 
   # used to say: Please don't resubmit the keychain patch option. It will never be accepted.
   # now here it is...
@@ -14,6 +14,7 @@ class OpensshPatched < Formula
   option "with-keychain-support", "Add native OS X Keychain and Launch Daemon support to ssh-agent" # doesn't work with HPN as of today FWIW...
 
   depends_on "autoconf" => :build # if build.with? "keychain-support"
+  depends_on "automake" => :build
   depends_on "openssl"
   depends_on "ldns" => :optional
   depends_on "pkg-config" => :build if build.with? "ldns"
@@ -36,8 +37,8 @@ class OpensshPatched < Formula
 
   if build.with? "gssapi-support"
     patch do
-      url "https://raw.githubusercontent.com/rdp/homebrew-openssh-gssapi/master/gssapi.8.1p1.patch" # was "http://sources.debian.org/data/main/o/openssh/1:8.1p1-1/debian/patches/gssapi.patch" 
-      sha256 "7875fe41ce090ba2bb3d76c396f9e6de863fbad34235bf97a4012d2f949909fb"
+      url "https://raw.githubusercontent.com/johfre/homebrew-openssh-gssapi/master/gssapi.8.4p1.patch" # was "https://sources.debian.org/data/main/o/openssh/1:8.4p1-2/debian/patches/gssapi.patch"
+      sha256 "15139c42894dd0ebd182608ecd7151a9eef6158aed30c676e7685e8407c6d1cb"
     end
   end
 

--- a/gssapi.8.4p1.patch
+++ b/gssapi.8.4p1.patch
@@ -1,4 +1,4 @@
-From 9da806e67101afdc0d3a1d304659927acf18f5c5 Mon Sep 17 00:00:00 2001
+From d1b7918f9bce6e997c7952ac795e18d09192b2a6 Mon Sep 17 00:00:00 2001
 From: Simon Wilkinson <simon@sxw.org.uk>
 Date: Sun, 9 Feb 2014 16:09:48 +0000
 Subject: GSSAPI key exchange support
@@ -16,14 +16,17 @@ have it merged into the main openssh package rather than having separate
 -krb5 packages (as we used to have).  It seems to have a generally good
 security history.
 
+Author: Simon Wilkinson <simon@sxw.org.uk>
+Author: Colin Watson <cjwatson@debian.org>
+Author: Jakub Jelen <jjelen@redhat.com>
 Origin: other, https://github.com/openssh-gsskex/openssh-gsskex/commits/debian/master
 Bug: https://bugzilla.mindrot.org/show_bug.cgi?id=1242
-Last-Updated: 2019-10-09
+Last-Updated: 2020-06-07
 
 Patch-Name: gssapi.patch
 ---
  Makefile.in     |   3 +-
- auth-krb5.c     |  17 +-
+ README.md       |  33 +++
  auth.c          |  96 +-------
  auth2-gss.c     |  56 ++++-
  auth2.c         |   2 +
@@ -34,14 +37,12 @@ Patch-Name: gssapi.patch
  gss-genr.c      | 300 +++++++++++++++++++++++-
  gss-serv-krb5.c |  85 ++++++-
  gss-serv.c      | 186 +++++++++++++--
- hmac.c          |   1 +
  kex.c           |  66 +++++-
  kex.h           |  29 +++
  kexdh.c         |  10 +
  kexgen.c        |   2 +-
  kexgssc.c       | 606 ++++++++++++++++++++++++++++++++++++++++++++++++
  kexgsss.c       | 474 +++++++++++++++++++++++++++++++++++++
- mac.c           |   1 +
  monitor.c       | 139 ++++++++++-
  monitor.h       |   2 +
  monitor_wrap.c  |  57 ++++-
@@ -51,98 +52,88 @@ Patch-Name: gssapi.patch
  servconf.c      |  47 ++++
  servconf.h      |   3 +
  session.c       |  10 +-
- ssh-gss.h       |  50 +++-
+ ssh-gss.h       |  54 ++++-
  ssh.1           |   8 +
- ssh.c           |   4 +-
+ ssh.c           |   6 +-
  ssh_config      |   2 +
  ssh_config.5    |  57 +++++
- sshconnect2.c   | 140 ++++++++++-
- sshd.c          | 120 +++++++++-
+ sshconnect2.c   | 154 +++++++++++-
+ sshd.c          |  62 ++++-
  sshd_config     |   2 +
  sshd_config.5   |  30 +++
  sshkey.c        |   3 +-
  sshkey.h        |   1 +
- 40 files changed, 2664 insertions(+), 160 deletions(-)
+ 38 files changed, 2640 insertions(+), 160 deletions(-)
  create mode 100644 kexgssc.c
  create mode 100644 kexgsss.c
 
 diff --git a/Makefile.in b/Makefile.in
-index adb1977e2..ab29e4f05 100644
+index acfb919da..56759c388 100644
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -100,6 +100,7 @@ LIBSSH_OBJS=${LIBOPENSSH_OBJS} \
+@@ -107,6 +107,7 @@ LIBSSH_OBJS=${LIBOPENSSH_OBJS} \
  	kex.o kexdh.o kexgex.o kexecdh.o kexc25519.o \
  	kexgexc.o kexgexs.o \
  	sntrup4591761.o kexsntrup4591761x25519.o kexgen.o \
 +	kexgssc.o \
- 	platform-pledge.o platform-tracing.o platform-misc.o
+ 	sftp-realpath.o platform-pledge.o platform-tracing.o platform-misc.o \
+ 	sshbuf-io.o
  
- 
-@@ -114,7 +115,7 @@ SSHDOBJS=sshd.o auth-rhosts.o auth-passwd.o \
+@@ -123,7 +124,7 @@ SSHDOBJS=sshd.o auth-rhosts.o auth-passwd.o \
  	auth-bsdauth.o auth2-hostbased.o auth2-kbdint.o \
  	auth2-none.o auth2-passwd.o auth2-pubkey.o \
  	monitor.o monitor_wrap.o auth-krb5.o \
 -	auth2-gss.o gss-serv.o gss-serv-krb5.o \
 +	auth2-gss.o gss-serv.o gss-serv-krb5.o kexgsss.o \
  	loginrec.o auth-pam.o auth-shadow.o auth-sia.o md5crypt.o \
- 	sftp-server.o sftp-common.o sftp-realpath.o \
+ 	sftp-server.o sftp-common.o \
  	sandbox-null.o sandbox-rlimit.o sandbox-systrace.o sandbox-darwin.o \
-diff --git a/auth-krb5.c b/auth-krb5.c
-index 3096f1c8e..204752e1b 100644
---- a/auth-krb5.c
-+++ b/auth-krb5.c
-@@ -182,8 +182,13 @@ auth_krb5_password(Authctxt *authctxt, const char *password)
+diff --git a/README.md b/README.md
+index 28fb43d2a..5b73d24c0 100644
+--- a/README.md
++++ b/README.md
+@@ -1,3 +1,36 @@
++Portable OpenSSH with GSSAPI Key Exchange patches
++=================================================
++
++Currently, there are two branches with gssapi key exchange related
++patches:
++
++ * fedora/master: Changes that are shipped in Fedora
++ * debian/master: Changes that are shipped in Debian
++
++The target is to converge to a shared repository with single master
++branch from where we could build releases for both OSes.
++
++
++What is in:
++
++ * The original patch implementing missing parts of RFC4462 by Simon Wilkinson
++   adapted to the current OpenSSH versions and with several fixes
++ * New methods for GSSAPI Kex from IETF draft [1] from Jakub Jelen
++
++
++Missing kerberos-related parts:
++
++ * .k5login and .kusers support available in Fedora [2] [3].
++ * Improved handling of kerberos ccache location [4]
++
++
++[1] https://tools.ietf.org/html/draft-ietf-curdle-gss-keyex-sha2-08
++[2] https://src.fedoraproject.org/rpms/openssh/blob/master/f/openssh-6.6p1-kuserok.patch
++[3] https://src.fedoraproject.org/rpms/openssh/blob/master/f/openssh-6.6p1-GSSAPIEnablek5users.patch
++[4] https://bugzilla.mindrot.org/show_bug.cgi?id=2775
++
++-------------------------------------------------------------------------------
++
+ # Portable OpenSSH
  
- 	len = strlen(authctxt->krb5_ticket_file) + 6;
- 	authctxt->krb5_ccname = xmalloc(len);
-+#ifdef USE_CCAPI
-+	snprintf(authctxt->krb5_ccname, len, "API:%s",
-+	    authctxt->krb5_ticket_file);
-+#else
- 	snprintf(authctxt->krb5_ccname, len, "FILE:%s",
- 	    authctxt->krb5_ticket_file);
-+#endif
- 
- #ifdef USE_PAM
- 	if (options.use_pam)
-@@ -240,15 +245,22 @@ krb5_cleanup_proc(Authctxt *authctxt)
- #ifndef HEIMDAL
- krb5_error_code
- ssh_krb5_cc_gen(krb5_context ctx, krb5_ccache *ccache) {
--	int tmpfd, ret, oerrno;
-+	int ret, oerrno;
- 	char ccname[40];
- 	mode_t old_umask;
-+#ifdef USE_CCAPI
-+	char cctemplate[] = "API:krb5cc_%d";
-+#else
-+	char cctemplate[] = "FILE:/tmp/krb5cc_%d_XXXXXXXXXX";
-+	int tmpfd;
-+#endif
- 
- 	ret = snprintf(ccname, sizeof(ccname),
--	    "FILE:/tmp/krb5cc_%d_XXXXXXXXXX", geteuid());
-+	    cctemplate, geteuid());
- 	if (ret < 0 || (size_t)ret >= sizeof(ccname))
- 		return ENOMEM;
- 
-+#ifndef USE_CCAPI
- 	old_umask = umask(0177);
- 	tmpfd = mkstemp(ccname + strlen("FILE:"));
- 	oerrno = errno;
-@@ -265,6 +277,7 @@ ssh_krb5_cc_gen(krb5_context ctx, krb5_ccache *ccache) {
- 		return oerrno;
- 	}
- 	close(tmpfd);
-+#endif
- 
- 	return (krb5_cc_resolve(ctx, ccname, ccache));
- }
+ [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/openssh.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:openssh)
 diff --git a/auth.c b/auth.c
-index ca450f4e4..47c27773c 100644
+index 9a5498b66..3d31ec860 100644
 --- a/auth.c
 +++ b/auth.c
-@@ -399,7 +399,8 @@ auth_root_allowed(struct ssh *ssh, const char *method)
+@@ -400,7 +400,8 @@ auth_root_allowed(struct ssh *ssh, const char *method)
  	case PERMIT_NO_PASSWD:
  		if (strcmp(method, "publickey") == 0 ||
  		    strcmp(method, "hostbased") == 0 ||
@@ -152,7 +143,7 @@ index ca450f4e4..47c27773c 100644
  			return 1;
  		break;
  	case PERMIT_FORCED_ONLY:
-@@ -723,99 +724,6 @@ fakepw(void)
+@@ -724,99 +725,6 @@ fakepw(void)
  	return (&fake);
  }
  
@@ -181,7 +172,7 @@ index ca450f4e4..47c27773c 100644
 -	if (getpeername(ssh_packet_get_connection_in(ssh),
 -	    (struct sockaddr *)&from, &fromlen) == -1) {
 -		debug("getpeername failed: %.100s", strerror(errno));
--		return strdup(ntop);
+-		return xstrdup(ntop);
 -	}
 -
 -	ipv64_normalise_mapped(&from, &fromlen);
@@ -193,7 +184,7 @@ index ca450f4e4..47c27773c 100644
 -	if (getnameinfo((struct sockaddr *)&from, fromlen, name, sizeof(name),
 -	    NULL, 0, NI_NAMEREQD) != 0) {
 -		/* Host name not found.  Use ip address. */
--		return strdup(ntop);
+-		return xstrdup(ntop);
 -	}
 -
 -	/*
@@ -208,7 +199,7 @@ index ca450f4e4..47c27773c 100644
 -		logit("Nasty PTR record \"%s\" is set up for %s, ignoring",
 -		    name, ntop);
 -		freeaddrinfo(ai);
--		return strdup(ntop);
+-		return xstrdup(ntop);
 -	}
 -
 -	/* Names are stored in lowercase. */
@@ -229,7 +220,7 @@ index ca450f4e4..47c27773c 100644
 -	if (getaddrinfo(name, NULL, &hints, &aitop) != 0) {
 -		logit("reverse mapping checking getaddrinfo for %.700s "
 -		    "[%s] failed.", name, ntop);
--		return strdup(ntop);
+-		return xstrdup(ntop);
 -	}
 -	/* Look for the address from the list of addresses. */
 -	for (ai = aitop; ai; ai = ai->ai_next) {
@@ -244,9 +235,9 @@ index ca450f4e4..47c27773c 100644
 -		/* Address not found for the host name. */
 -		logit("Address %.100s maps to %.600s, but this does not "
 -		    "map back to the address.", ntop, name);
--		return strdup(ntop);
+-		return xstrdup(ntop);
 -	}
--	return strdup(name);
+-	return xstrdup(name);
 -}
 -
  /*
@@ -348,7 +339,7 @@ index 9351e0428..d6446c0cf 100644
  	"gssapi-with-mic",
  	userauth_gssapi,
 diff --git a/auth2.c b/auth2.c
-index 0e7762242..1c217268c 100644
+index 242a7adbe..9fa1404b3 100644
 --- a/auth2.c
 +++ b/auth2.c
 @@ -73,6 +73,7 @@ extern Authmethod method_passwd;
@@ -368,7 +359,7 @@ index 0e7762242..1c217268c 100644
  #endif
  	&method_passwd,
 diff --git a/canohost.c b/canohost.c
-index abea9c6e6..9a00fc2cf 100644
+index abea9c6e6..8e81b5193 100644
 --- a/canohost.c
 +++ b/canohost.c
 @@ -35,6 +35,99 @@
@@ -400,7 +391,7 @@ index abea9c6e6..9a00fc2cf 100644
 +	if (getpeername(ssh_packet_get_connection_in(ssh),
 +	    (struct sockaddr *)&from, &fromlen) == -1) {
 +		debug("getpeername failed: %.100s", strerror(errno));
-+		return strdup(ntop);
++		return xstrdup(ntop);
 +	}
 +
 +	ipv64_normalise_mapped(&from, &fromlen);
@@ -412,7 +403,7 @@ index abea9c6e6..9a00fc2cf 100644
 +	if (getnameinfo((struct sockaddr *)&from, fromlen, name, sizeof(name),
 +	    NULL, 0, NI_NAMEREQD) != 0) {
 +		/* Host name not found.  Use ip address. */
-+		return strdup(ntop);
++		return xstrdup(ntop);
 +	}
 +
 +	/*
@@ -427,7 +418,7 @@ index abea9c6e6..9a00fc2cf 100644
 +		logit("Nasty PTR record \"%s\" is set up for %s, ignoring",
 +		    name, ntop);
 +		freeaddrinfo(ai);
-+		return strdup(ntop);
++		return xstrdup(ntop);
 +	}
 +
 +	/* Names are stored in lowercase. */
@@ -448,7 +439,7 @@ index abea9c6e6..9a00fc2cf 100644
 +	if (getaddrinfo(name, NULL, &hints, &aitop) != 0) {
 +		logit("reverse mapping checking getaddrinfo for %.700s "
 +		    "[%s] failed.", name, ntop);
-+		return strdup(ntop);
++		return xstrdup(ntop);
 +	}
 +	/* Look for the address from the list of addresses. */
 +	for (ai = aitop; ai; ai = ai->ai_next) {
@@ -463,9 +454,9 @@ index abea9c6e6..9a00fc2cf 100644
 +		/* Address not found for the host name. */
 +		logit("Address %.100s maps to %.600s, but this does not "
 +		    "map back to the address.", ntop, name);
-+		return strdup(ntop);
++		return xstrdup(ntop);
 +	}
-+	return strdup(name);
++	return xstrdup(name);
 +}
 +
  void
@@ -486,7 +477,7 @@ index 26d62855a..0cadc9f18 100644
  int		 get_peer_port(int);
  char		*get_local_ipaddr(int);
 diff --git a/clientloop.c b/clientloop.c
-index b5a1f7038..9def2a1a9 100644
+index 60b46d161..2cebea29f 100644
 --- a/clientloop.c
 +++ b/clientloop.c
 @@ -112,6 +112,10 @@
@@ -500,7 +491,7 @@ index b5a1f7038..9def2a1a9 100644
  /* import options */
  extern Options options;
  
-@@ -1373,9 +1377,18 @@ client_loop(struct ssh *ssh, int have_pty, int escape_char_arg,
+@@ -1368,9 +1372,18 @@ client_loop(struct ssh *ssh, int have_pty, int escape_char_arg,
  			break;
  
  		/* Do channel operations unless rekeying in progress. */
@@ -521,10 +512,10 @@ index b5a1f7038..9def2a1a9 100644
  		client_process_net_input(ssh, readset);
  
 diff --git a/configure.ac b/configure.ac
-index 3e93c0276..1c2512314 100644
+index 7005a503e..c8a96deb4 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -666,6 +666,30 @@ main() { if (NSVersionOfRunTimeLibrary("System") >= (60 << 16))
+@@ -679,6 +679,30 @@ main() { if (NSVersionOfRunTimeLibrary("System") >= (60 << 16))
  	    [Use tunnel device compatibility to OpenBSD])
  	AC_DEFINE([SSH_TUN_PREPEND_AF], [1],
  	    [Prepend the address family to IP tunnel traffic])
@@ -1065,11 +1056,11 @@ index a151bc1e4..ef9beb67c 100644
  
  #endif /* KRB5 */
 diff --git a/gss-serv.c b/gss-serv.c
-index ab3a15f0f..1d47870e7 100644
+index b5d4bb2d1..55f4d4bda 100644
 --- a/gss-serv.c
 +++ b/gss-serv.c
 @@ -1,7 +1,7 @@
- /* $OpenBSD: gss-serv.c,v 1.31 2018/07/09 21:37:55 markus Exp $ */
+ /* $OpenBSD: gss-serv.c,v 1.32 2020/03/13 03:17:07 djm Exp $ */
  
  /*
 - * Copyright (c) 2001-2003 Simon Wilkinson. All rights reserved.
@@ -1338,23 +1329,11 @@ index ab3a15f0f..1d47870e7 100644
  }
  
  /* Privileged */
-diff --git a/hmac.c b/hmac.c
-index 32688876d..a79e8569c 100644
---- a/hmac.c
-+++ b/hmac.c
-@@ -21,6 +21,7 @@
- 
- #include <stdlib.h>
- #include <string.h>
-+#include <stdlib.h>
- 
- #include "sshbuf.h"
- #include "digest.h"
 diff --git a/kex.c b/kex.c
-index 49d701568..e09355dbd 100644
+index aecb9394d..751cfc710 100644
 --- a/kex.c
 +++ b/kex.c
-@@ -55,11 +55,16 @@
+@@ -57,11 +57,16 @@
  #include "misc.h"
  #include "dispatch.h"
  #include "monitor.h"
@@ -1371,7 +1350,7 @@ index 49d701568..e09355dbd 100644
  /* prototype */
  static int kex_choose_conf(struct ssh *);
  static int kex_input_newkeys(int, u_int32_t, struct ssh *);
-@@ -113,15 +118,28 @@ static const struct kexalg kexalgs[] = {
+@@ -115,15 +120,28 @@ static const struct kexalg kexalgs[] = {
  #endif /* HAVE_EVP_SHA256 || !WITH_OPENSSL */
  	{ NULL, 0, -1, -1},
  };
@@ -1386,7 +1365,7 @@ index 49d701568..e09355dbd 100644
 +	    NID_X9_62_prime256v1, SSH_DIGEST_SHA256 },
 +	{ KEX_GSS_C25519_SHA256_ID, KEX_GSS_C25519_SHA256, 0, SSH_DIGEST_SHA256 },
 +#endif
-+	{ NULL, 0, -1, -1 },
++	{ NULL, 0, -1, -1},
 +};
  
 -char *
@@ -1403,7 +1382,7 @@ index 49d701568..e09355dbd 100644
  		if (ret != NULL)
  			ret[rlen++] = sep;
  		nlen = strlen(k->name);
-@@ -136,6 +154,18 @@ kex_alg_list(char sep)
+@@ -138,6 +156,18 @@ kex_alg_list(char sep)
  	return ret;
  }
  
@@ -1422,7 +1401,7 @@ index 49d701568..e09355dbd 100644
  static const struct kexalg *
  kex_alg_by_name(const char *name)
  {
-@@ -145,6 +175,10 @@ kex_alg_by_name(const char *name)
+@@ -147,6 +177,10 @@ kex_alg_by_name(const char *name)
  		if (strcmp(k->name, name) == 0)
  			return k;
  	}
@@ -1433,7 +1412,7 @@ index 49d701568..e09355dbd 100644
  	return NULL;
  }
  
-@@ -313,6 +347,29 @@ kex_assemble_names(char **listp, const char *def, const char *all)
+@@ -315,6 +349,29 @@ kex_assemble_names(char **listp, const char *def, const char *all)
  	return r;
  }
  
@@ -1463,7 +1442,7 @@ index 49d701568..e09355dbd 100644
  /* put algorithm proposal into buffer */
  int
  kex_prop2buf(struct sshbuf *b, char *proposal[PROPOSAL_MAX])
-@@ -696,6 +753,9 @@ kex_free(struct kex *kex)
+@@ -697,6 +754,9 @@ kex_free(struct kex *kex)
  	sshbuf_free(kex->server_version);
  	sshbuf_free(kex->client_pub);
  	free(kex->session_id);
@@ -1544,10 +1523,10 @@ index a5ae6ac05..fe7141414 100644
  	__attribute__((__bounded__(__minbytes__, 1, CURVE25519_SIZE)))
  	__attribute__((__bounded__(__minbytes__, 2, CURVE25519_SIZE)));
 diff --git a/kexdh.c b/kexdh.c
-index 67133e339..edaa46762 100644
+index 6e0159f9f..d024a8b9a 100644
 --- a/kexdh.c
 +++ b/kexdh.c
-@@ -48,13 +48,23 @@ kex_dh_keygen(struct kex *kex)
+@@ -49,13 +49,23 @@ kex_dh_keygen(struct kex *kex)
  {
  	switch (kex->kex_type) {
  	case KEX_DH_GRP1_SHA1:
@@ -1572,7 +1551,7 @@ index 67133e339..edaa46762 100644
  		break;
  	case KEX_DH_GRP18_SHA512:
 diff --git a/kexgen.c b/kexgen.c
-index bb996b504..d353ed8b0 100644
+index 69348b964..c0e8c2f44 100644
 --- a/kexgen.c
 +++ b/kexgen.c
 @@ -44,7 +44,7 @@
@@ -2676,23 +2655,11 @@ index 000000000..60bc02deb
 +	return r;
 +}
 +#endif /* defined(GSSAPI) && defined(WITH_OPENSSL) */
-diff --git a/mac.c b/mac.c
-index f3dda6692..de346ed20 100644
---- a/mac.c
-+++ b/mac.c
-@@ -30,6 +30,7 @@
- #include <stdlib.h>
- #include <string.h>
- #include <stdio.h>
-+#include <stdlib.h>
- 
- #include "digest.h"
- #include "hmac.h"
 diff --git a/monitor.c b/monitor.c
-index 00af44f98..bead9e204 100644
+index 4cf79dfc9..11868952b 100644
 --- a/monitor.c
 +++ b/monitor.c
-@@ -147,6 +147,8 @@ int mm_answer_gss_setup_ctx(struct ssh *, int, struct sshbuf *);
+@@ -148,6 +148,8 @@ int mm_answer_gss_setup_ctx(struct ssh *, int, struct sshbuf *);
  int mm_answer_gss_accept_ctx(struct ssh *, int, struct sshbuf *);
  int mm_answer_gss_userok(struct ssh *, int, struct sshbuf *);
  int mm_answer_gss_checkmic(struct ssh *, int, struct sshbuf *);
@@ -2701,7 +2668,7 @@ index 00af44f98..bead9e204 100644
  #endif
  
  #ifdef SSH_AUDIT_EVENTS
-@@ -219,11 +221,18 @@ struct mon_table mon_dispatch_proto20[] = {
+@@ -220,11 +222,18 @@ struct mon_table mon_dispatch_proto20[] = {
      {MONITOR_REQ_GSSSTEP, 0, mm_answer_gss_accept_ctx},
      {MONITOR_REQ_GSSUSEROK, MON_ONCE|MON_AUTHDECIDE, mm_answer_gss_userok},
      {MONITOR_REQ_GSSCHECKMIC, MON_ONCE, mm_answer_gss_checkmic},
@@ -2720,7 +2687,7 @@ index 00af44f98..bead9e204 100644
  #ifdef WITH_OPENSSL
      {MONITOR_REQ_MODULI, 0, mm_answer_moduli},
  #endif
-@@ -292,6 +301,10 @@ monitor_child_preauth(struct ssh *ssh, struct monitor *pmonitor)
+@@ -293,6 +302,10 @@ monitor_child_preauth(struct ssh *ssh, struct monitor *pmonitor)
  	/* Permit requests for moduli and signatures */
  	monitor_permit(mon_dispatch, MONITOR_REQ_MODULI, 1);
  	monitor_permit(mon_dispatch, MONITOR_REQ_SIGN, 1);
@@ -2731,7 +2698,7 @@ index 00af44f98..bead9e204 100644
  
  	/* The first few requests do not require asynchronous access */
  	while (!authenticated) {
-@@ -405,6 +418,10 @@ monitor_child_postauth(struct ssh *ssh, struct monitor *pmonitor)
+@@ -406,6 +419,10 @@ monitor_child_postauth(struct ssh *ssh, struct monitor *pmonitor)
  	monitor_permit(mon_dispatch, MONITOR_REQ_MODULI, 1);
  	monitor_permit(mon_dispatch, MONITOR_REQ_SIGN, 1);
  	monitor_permit(mon_dispatch, MONITOR_REQ_TERM, 1);
@@ -2742,7 +2709,7 @@ index 00af44f98..bead9e204 100644
  
  	if (auth_opts->permit_pty_flag) {
  		monitor_permit(mon_dispatch, MONITOR_REQ_PTY, 1);
-@@ -1687,6 +1704,17 @@ monitor_apply_keystate(struct ssh *ssh, struct monitor *pmonitor)
+@@ -1725,6 +1742,17 @@ monitor_apply_keystate(struct ssh *ssh, struct monitor *pmonitor)
  # ifdef OPENSSL_HAS_ECC
  		kex->kex[KEX_ECDH_SHA2] = kex_gen_server;
  # endif
@@ -2760,7 +2727,7 @@ index 00af44f98..bead9e204 100644
  #endif /* WITH_OPENSSL */
  		kex->kex[KEX_C25519_SHA256] = kex_gen_server;
  		kex->kex[KEX_KEM_SNTRUP4591761X25519_SHA512] = kex_gen_server;
-@@ -1780,8 +1808,8 @@ mm_answer_gss_setup_ctx(struct ssh *ssh, int sock, struct sshbuf *m)
+@@ -1818,8 +1846,8 @@ mm_answer_gss_setup_ctx(struct ssh *ssh, int sock, struct sshbuf *m)
  	u_char *p;
  	int r;
  
@@ -2771,7 +2738,7 @@ index 00af44f98..bead9e204 100644
  
  	if ((r = sshbuf_get_string(m, &p, &len)) != 0)
  		fatal("%s: buffer error: %s", __func__, ssh_err(r));
-@@ -1813,8 +1841,8 @@ mm_answer_gss_accept_ctx(struct ssh *ssh, int sock, struct sshbuf *m)
+@@ -1851,8 +1879,8 @@ mm_answer_gss_accept_ctx(struct ssh *ssh, int sock, struct sshbuf *m)
  	OM_uint32 flags = 0; /* GSI needs this */
  	int r;
  
@@ -2782,7 +2749,7 @@ index 00af44f98..bead9e204 100644
  
  	if ((r = ssh_gssapi_get_buffer_desc(m, &in)) != 0)
  		fatal("%s: buffer error: %s", __func__, ssh_err(r));
-@@ -1834,6 +1862,7 @@ mm_answer_gss_accept_ctx(struct ssh *ssh, int sock, struct sshbuf *m)
+@@ -1872,6 +1900,7 @@ mm_answer_gss_accept_ctx(struct ssh *ssh, int sock, struct sshbuf *m)
  		monitor_permit(mon_dispatch, MONITOR_REQ_GSSSTEP, 0);
  		monitor_permit(mon_dispatch, MONITOR_REQ_GSSUSEROK, 1);
  		monitor_permit(mon_dispatch, MONITOR_REQ_GSSCHECKMIC, 1);
@@ -2790,7 +2757,7 @@ index 00af44f98..bead9e204 100644
  	}
  	return (0);
  }
-@@ -1845,8 +1874,8 @@ mm_answer_gss_checkmic(struct ssh *ssh, int sock, struct sshbuf *m)
+@@ -1883,8 +1912,8 @@ mm_answer_gss_checkmic(struct ssh *ssh, int sock, struct sshbuf *m)
  	OM_uint32 ret;
  	int r;
  
@@ -2801,7 +2768,7 @@ index 00af44f98..bead9e204 100644
  
  	if ((r = ssh_gssapi_get_buffer_desc(m, &gssbuf)) != 0 ||
  	    (r = ssh_gssapi_get_buffer_desc(m, &mic)) != 0)
-@@ -1872,13 +1901,17 @@ mm_answer_gss_checkmic(struct ssh *ssh, int sock, struct sshbuf *m)
+@@ -1910,13 +1939,17 @@ mm_answer_gss_checkmic(struct ssh *ssh, int sock, struct sshbuf *m)
  int
  mm_answer_gss_userok(struct ssh *ssh, int sock, struct sshbuf *m)
  {
@@ -2823,7 +2790,7 @@ index 00af44f98..bead9e204 100644
  
  	sshbuf_reset(m);
  	if ((r = sshbuf_put_u32(m, authenticated)) != 0)
-@@ -1887,7 +1920,11 @@ mm_answer_gss_userok(struct ssh *ssh, int sock, struct sshbuf *m)
+@@ -1925,7 +1958,11 @@ mm_answer_gss_userok(struct ssh *ssh, int sock, struct sshbuf *m)
  	debug3("%s: sending result %d", __func__, authenticated);
  	mm_request_send(sock, MONITOR_ANS_GSSUSEROK, m);
  
@@ -2836,7 +2803,7 @@ index 00af44f98..bead9e204 100644
  
  	if ((displayname = ssh_gssapi_displayname()) != NULL)
  		auth2_record_info(authctxt, "%s", displayname);
-@@ -1895,5 +1932,85 @@ mm_answer_gss_userok(struct ssh *ssh, int sock, struct sshbuf *m)
+@@ -1933,5 +1970,85 @@ mm_answer_gss_userok(struct ssh *ssh, int sock, struct sshbuf *m)
  	/* Monitor loop will terminate if authenticated */
  	return (authenticated);
  }
@@ -2936,10 +2903,10 @@ index 683e5e071..2b1a2d590 100644
  
  struct ssh;
 diff --git a/monitor_wrap.c b/monitor_wrap.c
-index 4169b7604..fdca39a6a 100644
+index 5e38d83eb..0e78cd006 100644
 --- a/monitor_wrap.c
 +++ b/monitor_wrap.c
-@@ -978,13 +978,15 @@ mm_ssh_gssapi_checkmic(Gssctxt *ctx, gss_buffer_t gssbuf, gss_buffer_t gssmic)
+@@ -993,13 +993,15 @@ mm_ssh_gssapi_checkmic(Gssctxt *ctx, gss_buffer_t gssbuf, gss_buffer_t gssmic)
  }
  
  int
@@ -2956,7 +2923,7 @@ index 4169b7604..fdca39a6a 100644
  
  	mm_request_send(pmonitor->m_recvfd, MONITOR_REQ_GSSUSEROK, m);
  	mm_request_receive_expect(pmonitor->m_recvfd,
-@@ -997,4 +999,57 @@ mm_ssh_gssapi_userok(char *user)
+@@ -1012,4 +1014,57 @@ mm_ssh_gssapi_userok(char *user)
  	debug3("%s: user %sauthenticated",__func__, authenticated ? "" : "not ");
  	return (authenticated);
  }
@@ -3015,10 +2982,10 @@ index 4169b7604..fdca39a6a 100644
 +
  #endif /* GSSAPI */
 diff --git a/monitor_wrap.h b/monitor_wrap.h
-index 191277f3a..92dda574b 100644
+index 0db38c206..75aef1c74 100644
 --- a/monitor_wrap.h
 +++ b/monitor_wrap.h
-@@ -63,8 +63,10 @@ int mm_sshkey_verify(const struct sshkey *, const u_char *, size_t,
+@@ -65,8 +65,10 @@ int mm_sshkey_verify(const struct sshkey *, const u_char *, size_t,
  OM_uint32 mm_ssh_gssapi_server_ctx(Gssctxt **, gss_OID);
  OM_uint32 mm_ssh_gssapi_accept_ctx(Gssctxt *,
     gss_buffer_desc *, gss_buffer_desc *, OM_uint32 *);
@@ -3031,7 +2998,7 @@ index 191277f3a..92dda574b 100644
  
  #ifdef USE_PAM
 diff --git a/readconf.c b/readconf.c
-index f78b4d6fe..3c68d1a88 100644
+index 554efd7c9..57dae55d1 100644
 --- a/readconf.c
 +++ b/readconf.c
 @@ -67,6 +67,7 @@
@@ -3042,7 +3009,7 @@ index f78b4d6fe..3c68d1a88 100644
  
  /* Format of the configuration file:
  
-@@ -162,6 +163,8 @@ typedef enum {
+@@ -160,6 +161,8 @@ typedef enum {
  	oClearAllForwardings, oNoHostAuthenticationForLocalhost,
  	oEnableSSHKeysign, oRekeyLimit, oVerifyHostKeyDNS, oConnectTimeout,
  	oAddressFamily, oGssAuthentication, oGssDelegateCreds,
@@ -3051,7 +3018,7 @@ index f78b4d6fe..3c68d1a88 100644
  	oServerAliveInterval, oServerAliveCountMax, oIdentitiesOnly,
  	oSendEnv, oSetEnv, oControlPath, oControlMaster, oControlPersist,
  	oHashKnownHosts,
-@@ -202,10 +205,22 @@ static struct {
+@@ -204,10 +207,22 @@ static struct {
  	/* Sometimes-unsupported options */
  #if defined(GSSAPI)
  	{ "gssapiauthentication", oGssAuthentication },
@@ -3074,7 +3041,7 @@ index f78b4d6fe..3c68d1a88 100644
  #endif
  #ifdef ENABLE_PKCS11
  	{ "pkcs11provider", oPKCS11Provider },
-@@ -988,10 +1003,42 @@ parse_time:
+@@ -1068,10 +1083,42 @@ parse_time:
  		intptr = &options->gss_authentication;
  		goto parse_flag;
  
@@ -3117,7 +3084,7 @@ index f78b4d6fe..3c68d1a88 100644
  	case oBatchMode:
  		intptr = &options->batch_mode;
  		goto parse_flag;
-@@ -1863,7 +1910,13 @@ initialize_options(Options * options)
+@@ -1976,7 +2023,13 @@ initialize_options(Options * options)
  	options->pubkey_authentication = -1;
  	options->challenge_response_authentication = -1;
  	options->gss_authentication = -1;
@@ -3131,7 +3098,7 @@ index f78b4d6fe..3c68d1a88 100644
  	options->password_authentication = -1;
  	options->kbd_interactive_authentication = -1;
  	options->kbd_interactive_devices = NULL;
-@@ -2009,8 +2062,18 @@ fill_default_options(Options * options)
+@@ -2125,8 +2178,18 @@ fill_default_options(Options * options)
  		options->challenge_response_authentication = 1;
  	if (options->gss_authentication == -1)
  		options->gss_authentication = 0;
@@ -3150,7 +3117,7 @@ index f78b4d6fe..3c68d1a88 100644
  	if (options->password_authentication == -1)
  		options->password_authentication = 1;
  	if (options->kbd_interactive_authentication == -1)
-@@ -2625,7 +2688,14 @@ dump_client_config(Options *o, const char *host)
+@@ -2776,7 +2839,14 @@ dump_client_config(Options *o, const char *host)
  	dump_cfg_fmtint(oGatewayPorts, o->fwd_opts.gateway_ports);
  #ifdef GSSAPI
  	dump_cfg_fmtint(oGssAuthentication, o->gss_authentication);
@@ -3166,10 +3133,10 @@ index f78b4d6fe..3c68d1a88 100644
  	dump_cfg_fmtint(oHashKnownHosts, o->hash_known_hosts);
  	dump_cfg_fmtint(oHostbasedAuthentication, o->hostbased_authentication);
 diff --git a/readconf.h b/readconf.h
-index 8e36bf32a..0bff6d80a 100644
+index d6a15550d..3803eeddf 100644
 --- a/readconf.h
 +++ b/readconf.h
-@@ -40,7 +40,13 @@ typedef struct {
+@@ -41,7 +41,13 @@ typedef struct {
  	int     challenge_response_authentication;
  					/* Try S/Key or TIS, authentication. */
  	int     gss_authentication;	/* Try GSS authentication */
@@ -3184,10 +3151,10 @@ index 8e36bf32a..0bff6d80a 100644
  						 * authentication. */
  	int     kbd_interactive_authentication; /* Try keyboard-interactive auth. */
 diff --git a/servconf.c b/servconf.c
-index e76f9c39e..f63eb0b94 100644
+index f08e37477..ded8f4a87 100644
 --- a/servconf.c
 +++ b/servconf.c
-@@ -64,6 +64,7 @@
+@@ -70,6 +70,7 @@
  #include "auth.h"
  #include "myproposal.h"
  #include "digest.h"
@@ -3195,7 +3162,7 @@ index e76f9c39e..f63eb0b94 100644
  
  static void add_listen_addr(ServerOptions *, const char *,
      const char *, int);
-@@ -124,8 +125,11 @@ initialize_server_options(ServerOptions *options)
+@@ -134,8 +135,11 @@ initialize_server_options(ServerOptions *options)
  	options->kerberos_ticket_cleanup = -1;
  	options->kerberos_get_afs_token = -1;
  	options->gss_authentication=-1;
@@ -3207,7 +3174,7 @@ index e76f9c39e..f63eb0b94 100644
  	options->password_authentication = -1;
  	options->kbd_interactive_authentication = -1;
  	options->challenge_response_authentication = -1;
-@@ -351,10 +355,18 @@ fill_default_server_options(ServerOptions *options)
+@@ -376,10 +380,18 @@ fill_default_server_options(ServerOptions *options)
  		options->kerberos_get_afs_token = 0;
  	if (options->gss_authentication == -1)
  		options->gss_authentication = 0;
@@ -3226,7 +3193,7 @@ index e76f9c39e..f63eb0b94 100644
  	if (options->password_authentication == -1)
  		options->password_authentication = 1;
  	if (options->kbd_interactive_authentication == -1)
-@@ -498,6 +510,7 @@ typedef enum {
+@@ -523,6 +535,7 @@ typedef enum {
  	sHostKeyAlgorithms,
  	sClientAliveInterval, sClientAliveCountMax, sAuthorizedKeysFile,
  	sGssAuthentication, sGssCleanupCreds, sGssStrictAcceptor,
@@ -3234,7 +3201,7 @@ index e76f9c39e..f63eb0b94 100644
  	sAcceptEnv, sSetEnv, sPermitTunnel,
  	sMatch, sPermitOpen, sPermitListen, sForceCommand, sChrootDirectory,
  	sUsePrivilegeSeparation, sAllowAgentForwarding,
-@@ -572,12 +585,22 @@ static struct {
+@@ -600,12 +613,22 @@ static struct {
  #ifdef GSSAPI
  	{ "gssapiauthentication", sGssAuthentication, SSHCFG_ALL },
  	{ "gssapicleanupcredentials", sGssCleanupCreds, SSHCFG_GLOBAL },
@@ -3257,7 +3224,7 @@ index e76f9c39e..f63eb0b94 100644
  	{ "passwordauthentication", sPasswordAuthentication, SSHCFG_ALL },
  	{ "kbdinteractiveauthentication", sKbdInteractiveAuthentication, SSHCFG_ALL },
  	{ "challengeresponseauthentication", sChallengeResponseAuthentication, SSHCFG_GLOBAL },
-@@ -1488,6 +1511,10 @@ process_server_config_line(ServerOptions *options, char *line,
+@@ -1557,6 +1580,10 @@ process_server_config_line_depth(ServerOptions *options, char *line,
  		intptr = &options->gss_authentication;
  		goto parse_flag;
  
@@ -3268,7 +3235,7 @@ index e76f9c39e..f63eb0b94 100644
  	case sGssCleanupCreds:
  		intptr = &options->gss_cleanup_creds;
  		goto parse_flag;
-@@ -1496,6 +1523,22 @@ process_server_config_line(ServerOptions *options, char *line,
+@@ -1565,6 +1592,22 @@ process_server_config_line_depth(ServerOptions *options, char *line,
  		intptr = &options->gss_strict_acceptor;
  		goto parse_flag;
  
@@ -3291,7 +3258,7 @@ index e76f9c39e..f63eb0b94 100644
  	case sPasswordAuthentication:
  		intptr = &options->password_authentication;
  		goto parse_flag;
-@@ -2585,6 +2628,10 @@ dump_config(ServerOptions *o)
+@@ -2808,6 +2851,10 @@ dump_config(ServerOptions *o)
  #ifdef GSSAPI
  	dump_cfg_fmtint(sGssAuthentication, o->gss_authentication);
  	dump_cfg_fmtint(sGssCleanupCreds, o->gss_cleanup_creds);
@@ -3303,10 +3270,10 @@ index e76f9c39e..f63eb0b94 100644
  	dump_cfg_fmtint(sPasswordAuthentication, o->password_authentication);
  	dump_cfg_fmtint(sKbdInteractiveAuthentication,
 diff --git a/servconf.h b/servconf.h
-index 5483da051..29329ba1f 100644
+index 1df8f3db8..f10908e5b 100644
 --- a/servconf.h
 +++ b/servconf.h
-@@ -126,8 +126,11 @@ typedef struct {
+@@ -138,8 +138,11 @@ typedef struct {
  	int     kerberos_get_afs_token;		/* If true, try to get AFS token if
  						 * authenticated with Kerberos. */
  	int     gss_authentication;	/* If true, permit GSSAPI authentication */
@@ -3319,10 +3286,10 @@ index 5483da051..29329ba1f 100644
  						 * authentication. */
  	int     kbd_interactive_authentication;	/* If true, permit */
 diff --git a/session.c b/session.c
-index 8f5d7e0a4..f1a47f766 100644
+index 27ca8a104..857f17b3c 100644
 --- a/session.c
 +++ b/session.c
-@@ -2674,13 +2674,19 @@ do_cleanup(struct ssh *ssh, Authctxt *authctxt)
+@@ -2685,13 +2685,19 @@ do_cleanup(struct ssh *ssh, Authctxt *authctxt)
  
  #ifdef KRB5
  	if (options.kerberos_ticket_cleanup &&
@@ -3345,7 +3312,7 @@ index 8f5d7e0a4..f1a47f766 100644
  
  	/* remove agent socket */
 diff --git a/ssh-gss.h b/ssh-gss.h
-index 36180d07a..70dd36658 100644
+index 36180d07a..50d80bbca 100644
 --- a/ssh-gss.h
 +++ b/ssh-gss.h
 @@ -1,6 +1,6 @@
@@ -3356,7 +3323,7 @@ index 36180d07a..70dd36658 100644
   *
   * Redistribution and use in source and binary forms, with or without
   * modification, are permitted provided that the following conditions
-@@ -61,10 +61,30 @@
+@@ -61,10 +61,34 @@
  
  #define SSH_GSS_OIDTYPE 0x06
  
@@ -3376,8 +3343,12 @@ index 36180d07a..70dd36658 100644
 +#define KEX_GSS_C25519_SHA256_ID			"gss-curve25519-sha256-"
 +
 +#define        GSS_KEX_DEFAULT_KEX \
-+	KEX_GSS_GEX_SHA1_ID "," \
-+	KEX_GSS_GRP14_SHA1_ID
++	KEX_GSS_GRP14_SHA256_ID	"," \
++	KEX_GSS_GRP16_SHA512_ID	"," \
++	KEX_GSS_NISTP256_SHA256_ID "," \
++	KEX_GSS_C25519_SHA256_ID "," \
++	KEX_GSS_GRP14_SHA1_ID "," \
++	KEX_GSS_GEX_SHA1_ID
 +
  typedef struct {
  	char *filename;
@@ -3387,7 +3358,7 @@ index 36180d07a..70dd36658 100644
  	void *data;
  } ssh_gssapi_ccache;
  
-@@ -72,8 +92,11 @@ typedef struct {
+@@ -72,8 +96,11 @@ typedef struct {
  	gss_buffer_desc displayname;
  	gss_buffer_desc exportedname;
  	gss_cred_id_t creds;
@@ -3399,7 +3370,7 @@ index 36180d07a..70dd36658 100644
  } ssh_gssapi_client;
  
  typedef struct ssh_gssapi_mech_struct {
-@@ -84,6 +107,7 @@ typedef struct ssh_gssapi_mech_struct {
+@@ -84,6 +111,7 @@ typedef struct ssh_gssapi_mech_struct {
  	int (*userok) (ssh_gssapi_client *, char *);
  	int (*localname) (ssh_gssapi_client *, char **);
  	void (*storecreds) (ssh_gssapi_client *);
@@ -3407,7 +3378,7 @@ index 36180d07a..70dd36658 100644
  } ssh_gssapi_mech;
  
  typedef struct {
-@@ -94,10 +118,11 @@ typedef struct {
+@@ -94,10 +122,11 @@ typedef struct {
  	gss_OID		oid; /* client */
  	gss_cred_id_t	creds; /* server */
  	gss_name_t	client; /* server */
@@ -3420,7 +3391,7 @@ index 36180d07a..70dd36658 100644
  
  int  ssh_gssapi_check_oid(Gssctxt *, void *, size_t);
  void ssh_gssapi_set_oid_data(Gssctxt *, void *, size_t);
-@@ -109,6 +134,7 @@ OM_uint32 ssh_gssapi_test_oid_supported(OM_uint32 *, gss_OID, int *);
+@@ -109,6 +138,7 @@ OM_uint32 ssh_gssapi_test_oid_supported(OM_uint32 *, gss_OID, int *);
  
  struct sshbuf;
  int ssh_gssapi_get_buffer_desc(struct sshbuf *, gss_buffer_desc *);
@@ -3428,7 +3399,7 @@ index 36180d07a..70dd36658 100644
  
  OM_uint32 ssh_gssapi_import_name(Gssctxt *, const char *);
  OM_uint32 ssh_gssapi_init_ctx(Gssctxt *, int,
-@@ -123,17 +149,33 @@ void ssh_gssapi_delete_ctx(Gssctxt **);
+@@ -123,17 +153,33 @@ void ssh_gssapi_delete_ctx(Gssctxt **);
  OM_uint32 ssh_gssapi_sign(Gssctxt *, gss_buffer_t, gss_buffer_t);
  void ssh_gssapi_buildmic(struct sshbuf *, const char *,
      const char *, const char *);
@@ -3465,10 +3436,10 @@ index 36180d07a..70dd36658 100644
  
  #endif /* _SSH_GSS_H */
 diff --git a/ssh.1 b/ssh.1
-index 424d6c3e8..26940ad55 100644
+index 555317887..be8e964f0 100644
 --- a/ssh.1
 +++ b/ssh.1
-@@ -497,7 +497,13 @@ For full details of the options listed below, and their possible values, see
+@@ -506,7 +506,13 @@ For full details of the options listed below, and their possible values, see
  .It GatewayPorts
  .It GlobalKnownHostsFile
  .It GSSAPIAuthentication
@@ -3482,7 +3453,7 @@ index 424d6c3e8..26940ad55 100644
  .It HashKnownHosts
  .It Host
  .It HostbasedAuthentication
-@@ -573,6 +579,8 @@ flag),
+@@ -582,6 +588,8 @@ flag),
  (supported message integrity codes),
  .Ar kex
  (key exchange algorithms),
@@ -3492,29 +3463,31 @@ index 424d6c3e8..26940ad55 100644
  (key types),
  .Ar key-cert
 diff --git a/ssh.c b/ssh.c
-index ee51823cd..2da9f5d0d 100644
+index f34ca0d71..bb98a7e2d 100644
 --- a/ssh.c
 +++ b/ssh.c
-@@ -736,6 +736,8 @@ main(int ac, char **av)
- 				cp = mac_alg_list('\n');
- 			else if (strcmp(optarg, "kex") == 0)
+@@ -801,6 +801,8 @@ main(int ac, char **av)
+ 			else if (strcmp(optarg, "kex") == 0 ||
+ 			    strcasecmp(optarg, "KexAlgorithms") == 0)
  				cp = kex_alg_list('\n');
 +			else if (strcmp(optarg, "kex-gss") == 0)
 +				cp = kex_gss_alg_list('\n');
  			else if (strcmp(optarg, "key") == 0)
  				cp = sshkey_alg_list(0, 0, 0, '\n');
  			else if (strcmp(optarg, "key-cert") == 0)
-@@ -748,7 +750,7 @@ main(int ac, char **av)
- 				cp = xstrdup("2");
- 			else if (strcmp(optarg, "help") == 0) {
+@@ -826,8 +828,8 @@ main(int ac, char **av)
+ 			} else if (strcmp(optarg, "help") == 0) {
  				cp = xstrdup(
--				    "cipher\ncipher-auth\nkex\nkey\n"
-+				    "cipher\ncipher-auth\nkex\nkex-gss\nkey\n"
- 				    "key-cert\nkey-plain\nmac\n"
- 				    "protocol-version\nsig");
+ 				    "cipher\ncipher-auth\ncompression\nkex\n"
+-				    "key\nkey-cert\nkey-plain\nkey-sig\nmac\n"
+-				    "protocol-version\nsig");
++				    "kex-gss\nkey\nkey-cert\nkey-plain\n"
++				    "key-sig\nmac\nprotocol-version\nsig");
  			}
+ 			if (cp == NULL)
+ 				fatal("Unsupported query \"%s\"", optarg);
 diff --git a/ssh_config b/ssh_config
-index 5e8ef548b..1ff999b68 100644
+index 842ea866c..52aae8692 100644
 --- a/ssh_config
 +++ b/ssh_config
 @@ -24,6 +24,8 @@
@@ -3527,10 +3500,10 @@ index 5e8ef548b..1ff999b68 100644
  #   CheckHostIP yes
  #   AddressFamily any
 diff --git a/ssh_config.5 b/ssh_config.5
-index 02a87892d..f4668673b 100644
+index 6be1f1aa2..bd86d000c 100644
 --- a/ssh_config.5
 +++ b/ssh_config.5
-@@ -758,10 +758,67 @@ The default is
+@@ -779,10 +779,67 @@ The default is
  Specifies whether user authentication based on GSSAPI is allowed.
  The default is
  .Cm no .
@@ -3593,16 +3566,16 @@ index 02a87892d..f4668673b 100644
 +.Ed
 +.Pp
 +The default is
-+.Dq gss-gex-sha1-,gss-group14-sha1- .
-+This option only applies to protocol version 2 connections using GSSAPI.
++.Dq gss-group14-sha256-,gss-group16-sha512-,gss-nistp256-sha256-,gss-curve25519-sha256-,gss-gex-sha1-,gss-group14-sha1- .
++This option only applies to connections using GSSAPI.
  .It Cm HashKnownHosts
  Indicates that
  .Xr ssh 1
 diff --git a/sshconnect2.c b/sshconnect2.c
-index 87fa70a40..a4ec75ca1 100644
+index f64aae66a..c47fc31a6 100644
 --- a/sshconnect2.c
 +++ b/sshconnect2.c
-@@ -78,8 +78,6 @@
+@@ -80,8 +80,6 @@
  #endif
  
  /* import */
@@ -3611,9 +3584,9 @@ index 87fa70a40..a4ec75ca1 100644
  extern Options options;
  
  /*
-@@ -161,6 +159,11 @@ ssh_kex2(struct ssh *ssh, char *host, struct sockaddr *hostaddr, u_short port)
+@@ -210,6 +208,11 @@ ssh_kex2(struct ssh *ssh, char *host, struct sockaddr *hostaddr, u_short port)
  	char *s, *all_key;
- 	int r;
+ 	int r, use_known_hosts_order = 0;
  
 +#if defined(GSSAPI) && defined(WITH_OPENSSL)
 +	char *orig = NULL, *gss = NULL;
@@ -3623,8 +3596,8 @@ index 87fa70a40..a4ec75ca1 100644
  	xxx_host = host;
  	xxx_hostaddr = hostaddr;
  
-@@ -193,6 +196,35 @@ ssh_kex2(struct ssh *ssh, char *host, struct sockaddr *hostaddr, u_short port)
- 		    order_hostkeyalgs(host, hostaddr, port));
+@@ -253,6 +256,41 @@ ssh_kex2(struct ssh *ssh, char *host, struct sockaddr *hostaddr, u_short port)
+ 		    compat_pkalg_proposal(options.hostkeyalgorithms);
  	}
  
 +#if defined(GSSAPI) && defined(WITH_OPENSSL)
@@ -3633,12 +3606,18 @@ index 87fa70a40..a4ec75ca1 100644
 +		 * client to the key exchange algorithm proposal */
 +		orig = myproposal[PROPOSAL_KEX_ALGS];
 +
-+		if (options.gss_server_identity)
++		if (options.gss_server_identity) {
 +			gss_host = xstrdup(options.gss_server_identity);
-+		else if (options.gss_trust_dns)
++		} else if (options.gss_trust_dns) {
 +			gss_host = remote_hostname(ssh);
-+		else
++			/* Fall back to specified host if we are using proxy command
++			 * and can not use DNS on that socket */
++			if (strcmp(gss_host, "UNKNOWN") == 0) {
++				gss_host = xstrdup(host);
++			}
++		} else {
 +			gss_host = xstrdup(host);
++		}
 +
 +		gss = ssh_gssapi_client_mechanisms(gss_host,
 +		    options.gss_client_identity, options.gss_kex_algorithms);
@@ -3659,10 +3638,11 @@ index 87fa70a40..a4ec75ca1 100644
  	if (options.rekey_limit || options.rekey_interval)
  		ssh_packet_set_rekey_limits(ssh, options.rekey_limit,
  		    options.rekey_interval);
-@@ -211,16 +243,46 @@ ssh_kex2(struct ssh *ssh, char *host, struct sockaddr *hostaddr, u_short port)
+@@ -271,16 +309,46 @@ ssh_kex2(struct ssh *ssh, char *host, struct sockaddr *hostaddr, u_short port)
  # ifdef OPENSSL_HAS_ECC
  	ssh->kex->kex[KEX_ECDH_SHA2] = kex_gen_client;
  # endif
+-#endif
 +# ifdef GSSAPI
 +	if (options.gss_keyex) {
 +		ssh->kex->kex[KEX_GSS_GRP1_SHA1] = kexgss_client;
@@ -3674,7 +3654,7 @@ index 87fa70a40..a4ec75ca1 100644
 +		ssh->kex->kex[KEX_GSS_C25519_SHA256] = kexgss_client;
 +	}
 +# endif
- #endif
++#endif /* WITH_OPENSSL */
  	ssh->kex->kex[KEX_C25519_SHA256] = kex_gen_client;
  	ssh->kex->kex[KEX_KEM_SNTRUP4591761X25519_SHA512] = kex_gen_client;
  	ssh->kex->verify_host_key=&verify_host_key_callback;
@@ -3706,7 +3686,7 @@ index 87fa70a40..a4ec75ca1 100644
  	if ((r = kex_prop2buf(ssh->kex->my, myproposal)) != 0)
  		fatal("kex_prop2buf: %s", ssh_err(r));
  
-@@ -317,6 +379,7 @@ static int input_gssapi_response(int type, u_int32_t, struct ssh *);
+@@ -377,6 +445,7 @@ static int input_gssapi_response(int type, u_int32_t, struct ssh *);
  static int input_gssapi_token(int type, u_int32_t, struct ssh *);
  static int input_gssapi_error(int, u_int32_t, struct ssh *);
  static int input_gssapi_errtok(int, u_int32_t, struct ssh *);
@@ -3714,7 +3694,7 @@ index 87fa70a40..a4ec75ca1 100644
  #endif
  
  void	userauth(struct ssh *, char *);
-@@ -333,6 +396,11 @@ static char *authmethods_get(void);
+@@ -393,6 +462,11 @@ static char *authmethods_get(void);
  
  Authmethod authmethods[] = {
  #ifdef GSSAPI
@@ -3726,18 +3706,24 @@ index 87fa70a40..a4ec75ca1 100644
  	{"gssapi-with-mic",
  		userauth_gssapi,
  		userauth_gssapi_cleanup,
-@@ -697,12 +765,25 @@ userauth_gssapi(struct ssh *ssh)
+@@ -763,12 +837,31 @@ userauth_gssapi(struct ssh *ssh)
  	OM_uint32 min;
  	int r, ok = 0;
  	gss_OID mech = NULL;
 +	char *gss_host;
 +
-+	if (options.gss_server_identity)
++	if (options.gss_server_identity) {
 +		gss_host = xstrdup(options.gss_server_identity);
-+	else if (options.gss_trust_dns)
++	} else if (options.gss_trust_dns) {
 +		gss_host = remote_hostname(ssh);
-+	else
++		/* Fall back to specified host if we are using proxy command
++		 * and can not use DNS on that socket */
++		if (strcmp(gss_host, "UNKNOWN") == 0) {
++			gss_host = authctxt->host;
++		}
++	} else {
 +		gss_host = xstrdup(authctxt->host);
++	}
  
  	/* Try one GSSAPI method at a time, rather than sending them all at
  	 * once. */
@@ -3753,7 +3739,7 @@ index 87fa70a40..a4ec75ca1 100644
  
  	/* Check to see whether the mechanism is usable before we offer it */
  	while (authctxt->mech_tried < authctxt->gss_supported_mechs->count &&
-@@ -711,13 +792,15 @@ userauth_gssapi(struct ssh *ssh)
+@@ -777,13 +870,15 @@ userauth_gssapi(struct ssh *ssh)
  		    elements[authctxt->mech_tried];
  		/* My DER encoding requires length<128 */
  		if (mech->length < 128 && ssh_gssapi_check_mechanism(&gssctxt,
@@ -3770,7 +3756,7 @@ index 87fa70a40..a4ec75ca1 100644
  	if (!ok || mech == NULL)
  		return 0;
  
-@@ -957,6 +1040,55 @@ input_gssapi_error(int type, u_int32_t plen, struct ssh *ssh)
+@@ -1023,6 +1118,55 @@ input_gssapi_error(int type, u_int32_t plen, struct ssh *ssh)
  	free(lang);
  	return r;
  }
@@ -3827,21 +3813,10 @@ index 87fa70a40..a4ec75ca1 100644
  
  static int
 diff --git a/sshd.c b/sshd.c
-index 11571c010..3a5c1ea78 100644
+index 8aa7f3df6..8c5d5822e 100644
 --- a/sshd.c
 +++ b/sshd.c
-@@ -123,6 +123,10 @@
- #include "version.h"
- #include "ssherr.h"
- 
-+#ifdef USE_SECURITY_SESSION_API
-+#include <Security/AuthSession.h>
-+#endif
-+
- /* Re-exec fds */
- #define REEXEC_DEVCRYPTO_RESERVED_FD	(STDERR_FILENO + 1)
- #define REEXEC_STARTUP_PIPE_FD		(STDERR_FILENO + 2)
-@@ -796,8 +800,8 @@ notify_hostkeys(struct ssh *ssh)
+@@ -816,8 +816,8 @@ notify_hostkeys(struct ssh *ssh)
  	}
  	debug3("%s: sent %u hostkeys", __func__, nkeys);
  	if (nkeys == 0)
@@ -3852,7 +3827,7 @@ index 11571c010..3a5c1ea78 100644
  		sshpkt_fatal(ssh, r, "%s: send", __func__);
  	sshbuf_free(buf);
  }
-@@ -1773,7 +1777,8 @@ main(int ac, char **av)
+@@ -1901,7 +1901,8 @@ main(int ac, char **av)
  		free(fp);
  	}
  	accumulate_host_timing_secret(cfg, NULL);
@@ -3862,68 +3837,7 @@ index 11571c010..3a5c1ea78 100644
  		logit("sshd: no hostkeys available -- exiting.");
  		exit(1);
  	}
-@@ -2069,6 +2074,60 @@ main(int ac, char **av)
- 	    rdomain == NULL ? "" : "\"");
- 	free(laddr);
- 
-+#ifdef USE_SECURITY_SESSION_API
-+	/*
-+	 * Create a new security session for use by the new user login if
-+	 * the current session is the root session or we are not launched
-+	 * by inetd (eg: debugging mode or server mode).  We do not
-+	 * necessarily need to create a session if we are launched from
-+	 * inetd because Panther xinetd will create a session for us.
-+	 *
-+	 * The only case where this logic will fail is if there is an
-+	 * inetd running in a non-root session which is not creating
-+	 * new sessions for us.  Then all the users will end up in the
-+	 * same session (bad).
-+	 *
-+	 * When the client exits, the session will be destroyed for us
-+	 * automatically.
-+	 *
-+	 * We must create the session before any credentials are stored
-+	 * (including AFS pags, which happens a few lines below).
-+	 */
-+	{
-+		OSStatus err = 0;
-+		SecuritySessionId sid = 0;
-+		SessionAttributeBits sattrs = 0;
-+
-+		err = SessionGetInfo(callerSecuritySession, &sid, &sattrs);
-+		if (err)
-+			error("SessionGetInfo() failed with error %.8X",
-+			    (unsigned) err);
-+		else
-+			debug("Current Session ID is %.8X / Session Attributes are %.8X",
-+			    (unsigned) sid, (unsigned) sattrs);
-+
-+		if (inetd_flag && !(sattrs & sessionIsRoot))
-+			debug("Running in inetd mode in a non-root session... "
-+			    "assuming inetd created the session for us.");
-+		else {
-+			debug("Creating new security session...");
-+			err = SessionCreate(0, sessionHasTTY | sessionIsRemote);
-+			if (err)
-+				error("SessionCreate() failed with error %.8X",
-+				    (unsigned) err);
-+
-+			err = SessionGetInfo(callerSecuritySession, &sid, 
-+			    &sattrs);
-+			if (err)
-+				error("SessionGetInfo() failed with error %.8X",
-+				    (unsigned) err);
-+			else
-+				debug("New Session ID is %.8X / Session Attributes are %.8X",
-+				    (unsigned) sid, (unsigned) sattrs);
-+		}
-+	}
-+#endif
-+
- 	/*
- 	 * We don't want to listen forever unless the other side
- 	 * successfully authenticates itself.  So we set up an alarm which is
-@@ -2265,6 +2324,48 @@ do_ssh2_kex(struct ssh *ssh)
+@@ -2393,6 +2394,48 @@ do_ssh2_kex(struct ssh *ssh)
  	myproposal[PROPOSAL_SERVER_HOST_KEY_ALGS] = compat_pkalg_proposal(
  	    list_hostkey_types());
  
@@ -3972,7 +3886,7 @@ index 11571c010..3a5c1ea78 100644
  	/* start key exchange */
  	if ((r = kex_setup(ssh, myproposal)) != 0)
  		fatal("kex_setup: %s", ssh_err(r));
-@@ -2280,7 +2381,18 @@ do_ssh2_kex(struct ssh *ssh)
+@@ -2408,7 +2451,18 @@ do_ssh2_kex(struct ssh *ssh)
  # ifdef OPENSSL_HAS_ECC
  	kex->kex[KEX_ECDH_SHA2] = kex_gen_server;
  # endif
@@ -4006,10 +3920,10 @@ index 19b7c91a1..2c48105f8 100644
  # Set this to 'yes' to enable PAM authentication, account processing,
  # and session processing. If this is enabled, PAM authentication will
 diff --git a/sshd_config.5 b/sshd_config.5
-index 9486f2a1c..cec3c3c4e 100644
+index 6fa421cae..eabbe9e73 100644
 --- a/sshd_config.5
 +++ b/sshd_config.5
-@@ -655,6 +655,11 @@ Specifies whether to automatically destroy the user's credentials cache
+@@ -644,6 +644,11 @@ Specifies whether to automatically destroy the user's credentials cache
  on logout.
  The default is
  .Cm yes .
@@ -4021,7 +3935,7 @@ index 9486f2a1c..cec3c3c4e 100644
  .It Cm GSSAPIStrictAcceptorCheck
  Determines whether to be strict about the identity of the GSSAPI acceptor
  a client authenticates against.
-@@ -669,6 +674,31 @@ machine's default store.
+@@ -658,6 +663,31 @@ machine's default store.
  This facility is provided to assist with operation on multi homed machines.
  The default is
  .Cm yes .
@@ -4048,24 +3962,24 @@ index 9486f2a1c..cec3c3c4e 100644
 +.Ed
 +.Pp
 +The default is
-+.Dq gss-gex-sha1-,gss-group14-sha1- .
-+This option only applies to protocol version 2 connections using GSSAPI.
++.Dq gss-group14-sha256-,gss-group16-sha512-,gss-nistp256-sha256-,gss-curve25519-sha256-,gss-gex-sha1-,gss-group14-sha1- .
++This option only applies to connections using GSSAPI.
  .It Cm HostbasedAcceptedKeyTypes
  Specifies the key types that will be accepted for hostbased authentication
  as a list of comma-separated patterns.
 diff --git a/sshkey.c b/sshkey.c
-index ef90563b3..4d2048b6a 100644
+index ac451f1a8..b88282e19 100644
 --- a/sshkey.c
 +++ b/sshkey.c
-@@ -145,6 +145,7 @@ static const struct keytype keytypes[] = {
- #  endif /* OPENSSL_HAS_NISTP521 */
+@@ -156,6 +156,7 @@ static const struct keytype keytypes[] = {
+ 	    KEY_ECDSA_SK_CERT, NID_X9_62_prime256v1, 1, 0 },
  # endif /* OPENSSL_HAS_ECC */
  #endif /* WITH_OPENSSL */
 +	{ "null", "null", NULL, KEY_NULL, 0, 0, 0 },
  	{ NULL, NULL, NULL, -1, -1, 0, 0 }
  };
  
-@@ -233,7 +234,7 @@ sshkey_alg_list(int certs_only, int plain_only, int include_sigonly, char sep)
+@@ -257,7 +258,7 @@ sshkey_alg_list(int certs_only, int plain_only, int include_sigonly, char sep)
  	const struct keytype *kt;
  
  	for (kt = keytypes; kt->type != -1; kt++) {
@@ -4075,13 +3989,13 @@ index ef90563b3..4d2048b6a 100644
  		if (!include_sigonly && kt->sigonly)
  			continue;
 diff --git a/sshkey.h b/sshkey.h
-index 1119a7b07..1bf30d055 100644
+index 2d8b62497..dc1c10597 100644
 --- a/sshkey.h
 +++ b/sshkey.h
-@@ -65,6 +65,7 @@ enum sshkey_types {
- 	KEY_ED25519_CERT,
- 	KEY_XMSS,
- 	KEY_XMSS_CERT,
+@@ -69,6 +69,7 @@ enum sshkey_types {
+ 	KEY_ECDSA_SK_CERT,
+ 	KEY_ED25519_SK,
+ 	KEY_ED25519_SK_CERT,
 +	KEY_NULL,
  	KEY_UNSPEC
  };


### PR DESCRIPTION
You might want to edit the gssapi patch location.

Had to add the automake build dep, otherwise autoreconf would complain:

```
==> autoreconf -i
Last 15 lines from /Users/johan/Library/Logs/Homebrew/openssh-patched/01.autoreconf:
2020-12-08 14:00:27 +0100

autoreconf -i

Can't exec "aclocal": No such file or directory at /usr/local/Cellar/autoconf/2.69/share/autoconf/Autom4te/FileUtils.pm line 326.
autoreconf: failed to run aclocal: No such file or directory

If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
  https://github.com/johfre/homebrew-openssh-gssapi/issues
```